### PR TITLE
Update default timeout to match puppeteer

### DIFF
--- a/pyppeteer/navigator_watcher.py
+++ b/pyppeteer/navigator_watcher.py
@@ -27,7 +27,7 @@ class NavigatorWatcher:
         options.update(kwargs)
         self._client = client
         self._ignoreHTTPSErrors = ignoreHTTPSErrors
-        self._timeout = options.get('timeout', 3000)
+        self._timeout = options.get('timeout', 30000)
         self._idleTime = options.get('networkIdleTimeout', 1000)
         self._idleTimer: Optional[Union[asyncio.Future, asyncio.Handle]] = None
         self._idleInflight = options.get('networkIdleInflight', 2)


### PR DESCRIPTION
Updating the default timeout from 3000ms (3 sec) to 30000ms (30 sec). This matches puppeteer's default implementation.

Source: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options